### PR TITLE
Add logic to avoid ffmpeg odd-height error

### DIFF
--- a/Modules/Admin/Http/Controllers/MediaUploadController.php
+++ b/Modules/Admin/Http/Controllers/MediaUploadController.php
@@ -121,6 +121,7 @@ class MediaUploadController extends Controller
             // Resize video
             $m_video_width = 480;
             $m_video_height = ceil($height * (480/$width));
+            if($m_video_height % 2 == 1) $m_video_height++; // If odd, add one
 
             $ffmpeg = FFMpeg::create();
             $m_video = $ffmpeg->open($video_path . '/original/' . $media_name);


### PR DESCRIPTION
In the admin MediaUploadController, the thumbnail logic uses a formula that, given a certain height and width/height ratio, will cause the resized output to have an odd-numbered height value. For whatever reason, this kills the ffmpeg.

For the reasonable trade-off of accepting an extra ~1px height in the output (e.g. 480x856 instead of 480x855), the error is avoided. The issue was being triggered by the two lines starting at the link below (122, 123), and the fix follows on line 24.
 https://github.com/natchiketa/curateship/blob/752d62b0c5ae0c0ce9523cee36dfe29305a55fd3/Modules/Admin/Http/Controllers/MediaUploadController.php#L122

Said fix being basically "if height isn't perfectly divisible by 2, then increment height by 1px"